### PR TITLE
Update ADO sync workflow to disable `bypass` rules.

### DIFF
--- a/.github/workflows/ado_sync.yml
+++ b/.github/workflows/ado_sync.yml
@@ -21,4 +21,4 @@ jobs:
           ado_new_state: "New"
           ado_active_state: "Active"
           ado_close_state: "Closed"
-          ado_bypassrules: true
+          ado_bypassrules: false


### PR DESCRIPTION
Remove `bypass` rule as we don't have permission to do that.