### PR TITLE
Fix concurrency bug in GitHubAppAuthentication

### DIFF
--- a/GitHub.Collectors/Authentication/GitHubAppAuthentication.cs
+++ b/GitHub.Collectors/Authentication/GitHubAppAuthentication.cs
@@ -64,12 +64,12 @@ namespace Microsoft.CloudMine.GitHub.Collectors.Authentication
                 throw new FatalTerminalException("dependencies must be set before generating authorization header");
             }
 
-            if (TokenCache.ContainsKey(this.organization))
-            {
-                TimeSpan timeToRefresh = TokenCache[this.organization].Item1.Subtract(TimeSpan.FromMinutes(15)).Subtract(DateTime.UtcNow);
+            if (TokenCache.TryGetValue(this.organization, out Tuple<DateTime, string> tokenEpiryAndToken))
+            { 
+                TimeSpan timeToRefresh = tokenEpiryAndToken.Item1.Subtract(TimeSpan.FromMinutes(15)).Subtract(DateTime.UtcNow);
                 if (timeToRefresh.TotalMilliseconds > 0)
                 {
-                    return TokenCache[this.organization].Item2;
+                    return tokenEpiryAndToken.Item2;
                 }
             }
 
@@ -81,9 +81,7 @@ namespace Microsoft.CloudMine.GitHub.Collectors.Authentication
 
         private async Task<string> FindInstallationId(string jwt)
         {
-            string cachedInstallationId;
-
-            if (OrgNameToInstallationIdMap.TryGetValue(this.organization, out cachedInstallationId))
+            if (OrgNameToInstallationIdMap.TryGetValue(this.organization, out string cachedInstallationId))
             {
                 return cachedInstallationId;
             }

--- a/GitHub.Collectors/Authentication/GitHubAppAuthentication.cs
+++ b/GitHub.Collectors/Authentication/GitHubAppAuthentication.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CloudMine.GitHub.Collectors.Authentication
                     {
                         string orgName = responseItem.SelectToken("$.account.login").Value<string>();
                         string installationId = responseItem.SelectToken("$.id").Value<string>();
-                        OrgNameToInstallationIdMap.[orgName] = installationId;
+                        OrgNameToInstallationIdMap[orgName] = installationId;
 
                         if (orgName.Equals(this.organization))
                         {

--- a/GitHub.Collectors/Authentication/GitHubAppAuthentication.cs
+++ b/GitHub.Collectors/Authentication/GitHubAppAuthentication.cs
@@ -16,6 +16,7 @@ using Microsoft.CloudMine.Core.Collectors.Web;
 using Newtonsoft.Json.Linq;
 using Microsoft.CloudMine.Core.Collectors.Authentication;
 using Microsoft.CloudMine.GitHub.Collectors.Web;
+using System.Collections.Concurrent;
 
 namespace Microsoft.CloudMine.GitHub.Collectors.Authentication
 {
@@ -37,8 +38,8 @@ namespace Microsoft.CloudMine.GitHub.Collectors.Authentication
         /// <summary>
         /// Maps an organization name to a Tuple containing an expiry date and the token itself.
         /// </summary>
-        private static Dictionary<string, Tuple<DateTime, string>> TokenCache = new Dictionary<string, Tuple<DateTime, string>>();
-        private static Dictionary<string, string> OrgNameToInstallationIdMap = new Dictionary<string, string>();
+        private static ConcurrentDictionary<string, Tuple<DateTime, string>> TokenCache = new ConcurrentDictionary<string, Tuple<DateTime, string>>();
+        private static ConcurrentDictionary<string, string> OrgNameToInstallationIdMap = new ConcurrentDictionary<string, string>();
 
         public GitHubAppAuthentication(int appId, GitHubHttpClient httpClient, string organization, string apiDomain, string gitHubAppKeyVaultUri, bool useInteractiveLogin)
         {
@@ -103,7 +104,7 @@ namespace Microsoft.CloudMine.GitHub.Collectors.Authentication
                     {
                         string orgName = responseItem.SelectToken("$.account.login").Value<string>();
                         string installationId = responseItem.SelectToken("$.id").Value<string>();
-                        OrgNameToInstallationIdMap.Add(orgName, installationId);
+                        OrgNameToInstallationIdMap.[orgName] = installationId;
 
                         if (orgName.Equals(this.organization))
                         {


### PR DESCRIPTION
We see errors with the following strucutre in telemetry:
```
An item with the same key has already been added. Key: <organization name>
```

This is because of GitHubAppAuthentication.cs:106 where multiple threads (functions) are trying to add (and sometimes override) the value of the installation id in the dictionary. In other words, this operation should be an equals (instead of Add), permitting overriding (always with the same value).

Moreover, since these are statis variables shared between multiple functions, both TokenCache and OrgNameToInstallationIdMap needs to be protected for concurrent access. We don't need full atomicity (it is totally fine that multiple functions try to retrieve the installation ID and overwrite it and/or generate a new token when/if needed), however, each operation should be atomic by itself. This is easily achieved / fixed via ConcurrentDictionary.