### PR TITLE
Temporarily increase function timeout to 7 days.

### DIFF
--- a/GitHub.Collectors.Functions/host.json
+++ b/GitHub.Collectors.Functions/host.json
@@ -11,7 +11,7 @@
       "enableDependencyTracking": false
     }
   },
-  "functionTimeout": "12:00:00",
+  "functionTimeout": "7.00:00:00",
   "extensions": {
     "queues": {
       "visibilityTimeout": "00:15:00",


### PR DESCRIPTION
Onboarding some organizations / repositories is taking longer than 12 hours. Temporarily increasing the function timeout to 7 days until we can better optimize this.