### PR TITLE
Fix WebHookProcessorContextWriter

### DIFF
--- a/GitHub.Collectors.Functions/GitHubFunctions.cs
+++ b/GitHub.Collectors.Functions/GitHubFunctions.cs
@@ -280,7 +280,7 @@ namespace Microsoft.CloudMine.GitHub.Collectors.Functions
                 TypeNameHandling = TypeNameHandling.None
             };
             Repository repositoryDetails = JsonConvert.DeserializeObject<Repository>(queueItem, serializerSettings);
-            FunctionContextWriter contextWriter = new FunctionContextWriter();
+            FunctionContextWriter<FunctionContext> contextWriter = new FunctionContextWriter<FunctionContext>();
             string identifier = $"EventsTimeline";
 
             FunctionContext context = new FunctionContext()
@@ -358,7 +358,7 @@ namespace Microsoft.CloudMine.GitHub.Collectors.Functions
             };
             OnboardingInput onboardingInput = JsonConvert.DeserializeObject<OnboardingInput>(queueItem, serializerSettings);
             Repository repositoryDetails = onboardingInput.ToRepository();
-            FunctionContextWriter contextWriter = new FunctionContextWriter();
+            FunctionContextWriter<FunctionContext> contextWriter = new FunctionContextWriter<FunctionContext>();
             string identifier = $"Onboarding";
 
             FunctionContext context = new FunctionContext()
@@ -544,7 +544,7 @@ namespace Microsoft.CloudMine.GitHub.Collectors.Functions
                 TypeNameHandling = TypeNameHandling.None
             };
             Repository repositoryDetails = JsonConvert.DeserializeObject<Repository>(queueItem, serializerSettings);
-            FunctionContextWriter contextWriter = new FunctionContextWriter();
+            FunctionContextWriter<FunctionContext> contextWriter = new FunctionContextWriter<FunctionContext>();
             string identifier = $"Traffic";
 
             FunctionContext context = new FunctionContext()

--- a/GitHub.Collectors.Tests/Config/GitHubConfigManagerTests.cs
+++ b/GitHub.Collectors.Tests/Config/GitHubConfigManagerTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Tests.Authentication
             StorageManager storageManager = this.configManager.GetStorageManager("Main", this.telemetryClient);
             string identifier = "identifier";
             FunctionContext functionContext = new FunctionContext();
-            FunctionContextWriter contextWriter = new FunctionContextWriter();
+            FunctionContextWriter<FunctionContext> contextWriter = new FunctionContextWriter<FunctionContext>();
             AdlsClientWrapper adlsClientWrapper = new AdlsClientWrapper();
             List<IRecordWriter> recordWriters = storageManager.InitializeRecordWriters(identifier, functionContext, contextWriter, adlsClientWrapper.AdlsClient);
             Assert.AreEqual(2, recordWriters.Count);

--- a/GitHub.Collectors/Context/WebHookProcessorContextWriter.cs
+++ b/GitHub.Collectors/Context/WebHookProcessorContextWriter.cs
@@ -6,10 +6,12 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.CloudMine.GitHub.Collectors.Context
 {
-    public class WebhookProcessorContextWriter : ContextWriter<WebhookProcessorContext>
+    public class WebhookProcessorContextWriter : FunctionContextWriter<WebhookProcessorContext>
     {
         public override void AugmentMetadata(JObject metadata, WebhookProcessorContext functionContext)
         {
+            base.AugmentMetadata(metadata, functionContext);
+
             string logicAppStartDate = functionContext.LogicAppStartDate;
             if (!string.IsNullOrEmpty(logicAppStartDate))
             {

--- a/GitHub.Collectors/Web/GitHubHttpClient.cs
+++ b/GitHub.Collectors/Web/GitHubHttpClient.cs
@@ -27,7 +27,6 @@ namespace Microsoft.CloudMine.GitHub.Collectors.Web
         private readonly ICache<ConditionalRequestTableEntity> requestCache;
         private readonly ITelemetryClient telemetryClient;
 
-
         public static ProductInfoHeaderValue GitHubProductInfoHeaderValue = new ProductInfoHeaderValue("CloudMineGitHubCollector", "1.0.0");
 
         private static readonly RetryRule[] RetryRuleCollection = new RetryRule[]


### PR DESCRIPTION
WebHookProcessContextWriter should have extended the ContextWriter since otherwise it is missing the common context properties e.g., collector type and session id. This was deployed and was the case in production for GitHub (main collector) for weeks if not months. This change fixes it.

Also change the existing FunctionContextWriter(s) with its generic version.