### PR TITLE
Fix concurrency bug for the way GitHubHttpClient uses Retry Rules

### DIFF
--- a/GitHub.Collectors/Web/RetryRules.cs
+++ b/GitHub.Collectors/Web/RetryRules.cs
@@ -16,26 +16,27 @@ namespace Microsoft.CloudMine.GitHub.Collectors.Web
         private static readonly TimeSpan[] ExponentialBackoffFastRetryStrategyDelays = new TimeSpan[] { TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(10), TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(5) };
         private static readonly TimeSpan[] ExponentialBackoffSlowRetryStrategyDelays = new TimeSpan[] { TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(30), TimeSpan.FromMinutes(2), TimeSpan.FromMinutes(5) };
 
-        public static readonly RetryRule GatewayTimeoutRetryRule = new RetryRule()
+        // Note: since retry rules are stateful (they track their remaining attempts), the following are defined as static methods rather than variables. This way, everytime the method is called, a new instance of the underlying object will be created and retry rules won't be shared.
+        public static RetryRule GatewayTimeoutRetryRule() => new RetryRule()
         {
             ShallRetryAsync = response => Task.FromResult(response.StatusCode == HttpStatusCode.GatewayTimeout),
             DelayBeforeRetries = ExponentialBackoffFastRetryStrategyDelays,
         };
 
-        public static readonly RetryRule BadGatewayRetryRule = new RetryRule()
+        public static RetryRule BadGatewayRetryRule() => new RetryRule()
         {
             ShallRetryAsync = response => Task.FromResult(response.StatusCode == HttpStatusCode.BadGateway),
             // Uses fast linear retry for BadGateway errors. The GitHub API will sometimes return this error transiently for several requests in a row.
             DelayBeforeRetries = LinearFastRetryStrategyDelays,
         };
 
-        public static readonly RetryRule InternalServerErrorRetryRule = new RetryRule()
+        public static RetryRule InternalServerErrorRetryRule() => new RetryRule()
         {
             ShallRetryAsync = response => Task.FromResult(response.StatusCode == HttpStatusCode.InternalServerError),
             DelayBeforeRetries = ExponentialBackoffFastRetryStrategyDelays,
         };
 
-        public static readonly RetryRule RateLimiterAbuseRetryRule = new RetryRule()
+        public static RetryRule RateLimiterAbuseRetryRule() => new RetryRule()
         {
             ShallRetryAsync = async response =>
             {


### PR DESCRIPTION
With recent changes RetryRule became stateful, and therefore cannot be shared between multiple instances of a GitHubHttpClient. These were used as static variables before in the HTTP client, potentially causing a concurrency bug. This change makes then non-static so that this is no longer possible.