### PR TITLE
Move CustomQueueProcessor to CEDAR/Core

### DIFF
--- a/GitHub.Collectors.Functions/ServiceStartup.cs
+++ b/GitHub.Collectors.Functions/ServiceStartup.cs
@@ -14,6 +14,7 @@ using Microsoft.WindowsAzure.Storage.Queue;
 using System.Threading;
 using System.Globalization;
 using Microsoft.WindowsAzure.Storage;
+using Microsoft.CloudMine.Core.Collectors.Collector;
 
 [assembly: FunctionsStartup(typeof(Microsoft.CloudMine.GitHub.Collectors.Functions.ServiceStartup))]
 
@@ -42,51 +43,7 @@ namespace Microsoft.CloudMine.GitHub.Collectors.Functions
             { 
             }
             builder.Services.AddSingleton(new GitHubConfigManager(settings));
-            // The default queue processor in Azure Functions move the poison messages to the poison queue with the default time-to-live, which is 7 days and this is not configurable.
-            // We want to have infinite time to live for such messages and therefore implement our own custom queue processor (and queue processor factory)
             builder.Services.AddSingleton<IQueueProcessorFactory, CustomQueueProcessorFactory>();
-        }
-    }
-
-    public class CustomQueueProcessorFactory : IQueueProcessorFactory
-    {
-        public QueueProcessor Create(QueueProcessorFactoryContext context)
-        {
-            return new CustomQueueProcessor(context);
-        }
-    }
-
-    public class CustomQueueProcessor : QueueProcessor
-    {
-        private readonly ILogger _logger;
-
-        public CustomQueueProcessor(QueueProcessorFactoryContext context) 
-            : base(context)
-        {
-            _logger = context.Logger;
-        }
-
-        /// <summary>
-        /// Base implementation is taken from the DefaultQueueProcessor:
-        /// https://github.com/Azure/azure-webjobs-sdk/blob/50df9323e730c62207b85273712081cf9803f8c2/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/QueueProcessor.cs#L161
-        /// </summary>
-        protected override async Task CopyMessageToPoisonQueueAsync(CloudQueueMessage message, CloudQueue poisonQueue, CancellationToken cancellationToken)
-        {
-            string msg = string.Format(CultureInfo.InvariantCulture, "Message has reached MaxDequeueCount of {0}. Moving message to queue '{1}'.", MaxDequeueCount, poisonQueue.Name);
-            _logger?.LogWarning(msg);
-
-            try 
-            {
-                await poisonQueue.CreateIfNotExistsAsync().ConfigureAwait(false);
-            }
-            catch
-            {
-                // Do this as a best-effort. This can fail e.g., due to multiple functions trying to do this at the same time.
-            }
-            await poisonQueue.AddMessageAsync(message, timeToLive: TimeSpan.MaxValue, null, new QueueRequestOptions(), new OperationContext()).ConfigureAwait(false);
-
-            var eventArgs = new PoisonMessageEventArgs(message, poisonQueue);
-            OnMessageAddedToPoisonQueue(eventArgs);
         }
     }
 }

--- a/GitHub.Collectors.Functions/ServiceStartup.cs
+++ b/GitHub.Collectors.Functions/ServiceStartup.cs
@@ -8,12 +8,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.CloudMine.Core.Collectors.IO;
 using System;
 using Microsoft.Azure.WebJobs.Host.Queues;
-using Microsoft.Extensions.Logging;
-using System.Threading.Tasks;
-using Microsoft.WindowsAzure.Storage.Queue;
-using System.Threading;
-using System.Globalization;
-using Microsoft.WindowsAzure.Storage;
 using Microsoft.CloudMine.Core.Collectors.Collector;
 
 [assembly: FunctionsStartup(typeof(Microsoft.CloudMine.GitHub.Collectors.Functions.ServiceStartup))]


### PR DESCRIPTION
Changes for Issue #68. Removes the CustomQueueProcessor implementation from service startup and uses the implementation in CEDAR/Core.