### PR TITLE
Move ADLS app ingestion details from local to global settings

### DIFF
--- a/GitHub.Collectors.Functions/ServiceStartup.cs
+++ b/GitHub.Collectors.Functions/ServiceStartup.cs
@@ -19,10 +19,7 @@ namespace Microsoft.CloudMine.GitHub.Collectors.Functions
     {
         public override void Configure(IFunctionsHostBuilder builder)
         {
-            // Write startupcode here.
-            builder.Services.AddSingleton<IHttpClient, HttpClientWrapper>();
-            builder.Services.AddSingleton<IAdlsClient, AdlsClientWrapper>();
-            
+            // Write startupcode here.            
             string settings = null;
             string settingsPath = Environment.GetEnvironmentVariable("SettingsPath");
             if (string.IsNullOrWhiteSpace(settingsPath))
@@ -34,9 +31,12 @@ namespace Microsoft.CloudMine.GitHub.Collectors.Functions
                 settings = AzureHelpers.GetBlobContentAsync("github-settings", settingsPath).ConfigureAwait(false).GetAwaiter().GetResult();
             }
             catch (Exception)
-            { 
+            {
             }
+            builder.Services.AddSingleton(settings);
             builder.Services.AddSingleton(new GitHubConfigManager(settings));
+            builder.Services.AddSingleton<IHttpClient, HttpClientWrapper>();
+            builder.Services.AddSingleton<IAdlsClient, AdlsClientWrapper>();
             builder.Services.AddSingleton<IQueueProcessorFactory, CustomQueueProcessorFactory>();
         }
     }

--- a/GitHub.Collectors.Functions/ServiceStartup.cs
+++ b/GitHub.Collectors.Functions/ServiceStartup.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CloudMine.GitHub.Collectors.Functions
             {
             }
             builder.Services.AddSingleton(settings);
-            builder.Services.AddSingleton(new GitHubConfigManager(settings));
+            builder.Services.AddSingleton<GitHubConfigManager>();
             builder.Services.AddSingleton<IHttpClient, HttpClientWrapper>();
             builder.Services.AddSingleton<IAdlsClient, AdlsClientWrapper>();
             builder.Services.AddSingleton<IQueueProcessorFactory, CustomQueueProcessorFactory>();

--- a/GitHub.Collectors.Functions/Settings.barebones.template.json
+++ b/GitHub.Collectors.Functions/Settings.barebones.template.json
@@ -1,16 +1,20 @@
 {
+  "ApiDomain": "<Api Domain for GitHub e.g., api.github.com>",
+
   "Authentication": {
     "Type": "Basic",
     "Identity": "<Username for your GitHub account>",
     "PersonalAccessTokenEnvironmentVariable": "PersonalAccessToken"
   },
+
   "Storage": [
-  {
-    "Type": "AzureBlob",
-    "RootContainer": "github",
-    "OutputQueueName": "github"
-  }
+    {
+      "Type": "AzureBlob",
+      "RootContainer": "github",
+      "OutputQueueName": "github"
+    }
   ],
+
   "Collectors": {
 
     "Main": {},

--- a/GitHub.Collectors.Functions/Settings.barebones.template.json
+++ b/GitHub.Collectors.Functions/Settings.barebones.template.json
@@ -1,27 +1,26 @@
 {
-    "Authentication": {
-        "Type": "Basic",
-        "Identity": "<Username for your GitHub account>",
-        "PersonalAccessTokenEnvironmentVariable": "PersonalAccessToken"
-    },
-    "Storage": [
-        {
-            "Type": "AzureBlob",
-            "RootContainer": "github",
-            "OutputQueueName": "github"
-        }
-    ],
-    "Collectors": {
+  "Authentication": {
+    "Type": "Basic",
+    "Identity": "<Username for your GitHub account>",
+    "PersonalAccessTokenEnvironmentVariable": "PersonalAccessToken"
+  },
+  "Storage": [
+  {
+    "Type": "AzureBlob",
+    "RootContainer": "github",
+    "OutputQueueName": "github"
+  }
+  ],
+  "Collectors": {
 
-        "Main": {},
+    "Main": {},
 
-        "Delta": {},
+    "Delta": {},
 
-        "Onboarding": {},
+    "Onboarding": {},
 
-        "TrafficTimer": {},
+    "TrafficTimer": {},
 
-        "Traffic": {}
-    },
-    "ApiDomain":  "api.github.com"
+    "Traffic": {}
+  }
 }

--- a/GitHub.Collectors.Functions/Settings.template.json
+++ b/GitHub.Collectors.Functions/Settings.template.json
@@ -1,5 +1,10 @@
 {
   "Authentication": {
+    "AdlsIngestionApplicationId": "<ID of application with ADLS write permissions>",
+    // Your local.settings.json (or function configuration if deployed to the cloud) should have a tuple that maps "AdlsIngestionApplicationSecret" to the actual value:
+    // For example,
+    // "AdlsIngestionApplicationSecret": "<ADLS secret>"
+    "AdlsIngestionApplicationSecretEnvironmentVariable": "AdlsIngestionApplicationSecret",
     "Type": "Basic",
     "Identity": "<GitHub identity>",
     // Your local.settings.json (or function configuration if deployed to the cloud) should have a tuple that maps "PersonalAccessToken" to the actual PAT value:
@@ -10,7 +15,8 @@
   "Storage": [
     {
       "Type": "AzureDataLakeStorageV1",
-      "RootFolder": "GitHub"
+      "RootFolder": "GitHub",
+      "Version": "<ADLS version>"
     },
     {
       "Type": "AzureBlob",

--- a/GitHub.Collectors.Functions/local.settings.barebones.template.json
+++ b/GitHub.Collectors.Functions/local.settings.barebones.template.json
@@ -1,17 +1,17 @@
 {
-    "IsEncrypted": false,
-    "Values": {
-        // You set the following values.
-        "Identity": "<Username for your GitHub account>",
-        "AzureWebJobsStorage": "<Connection string for your Azure Storage account>",
-        "APPINSIGHTS_INSTRUMENTATIONKEY": "<Instrumentation key for your Azure App Insights instance>",
-        "SettingsPath": "<Settings file path from the github-settings container on Azure. Ex. `Settings.json`.>",
-        // Must enable SSO for the organization the repo lives in (Ex. 'microsoft').
-        "PersonalAccessToken": "<Personal Access Token for your GitHub account>",
+  "IsEncrypted": false,
+  "Values": {
+    // You set the following values.
+    "Identity": "<Username for your GitHub account>",
+    "AzureWebJobsStorage": "<Connection string for your Azure Storage account>",
+    "APPINSIGHTS_INSTRUMENTATIONKEY": "<Instrumentation key for your Azure App Insights instance>",
+    "SettingsPath": "<Settings file path from the github-settings container on Azure. Ex. `Settings.json`.>",
+    // Must enable SSO for the organization the repo lives in (Ex. 'microsoft').
+    "PersonalAccessToken": "<Personal Access Token for your GitHub account>",
 
-        "FUNCTIONS_WORKER_RUNTIME": "dotnet",
-        // Disable timer-triggered functions for local debugging. The functions can be selectively enabled when running locally.
-        "AzureWebJobs.TrafficTimer.Disabled": "true",
-        "EventCountLimit": 100
-    }
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+    // Disable timer-triggered functions for local debugging. The functions can be selectively enabled when running locally.
+    "AzureWebJobs.TrafficTimer.Disabled": "true",
+    "EventCountLimit": 100
+  }
 }

--- a/GitHub.Collectors.Functions/local.settings.template.json
+++ b/GitHub.Collectors.Functions/local.settings.template.json
@@ -19,7 +19,6 @@
 
     "EventCountLimit": 100,
 
-    "AdlsIngestionApplicationId": "<ID of application with ADLS write permissions>",
     "AdlsIngestionApplicationSecret": "<Secret for application with ADLS write permissions>"
   }
 }

--- a/GitHub.Collectors.Tests/Config/GitHubConfigManagerTests.cs
+++ b/GitHub.Collectors.Tests/Config/GitHubConfigManagerTests.cs
@@ -25,13 +25,17 @@ namespace Microsoft.CloudMine.Core.Collectors.Tests.Authentication
         private GitHubConfigManager configManager;
         private GitHubHttpClient httpClient;
         private ITelemetryClient telemetryClient;
+        private string jsonInput;
         private string apiDomain;
 
         [TestInitialize]
         public void Setup()
         {
-            string jsonInput = @"
+            this.jsonInput = @"
             {
+                'AdlsIngestionApplicationId': '',
+                'AdlsIngestionApplicationSecretEnvironmentVariable': 'AdlsIngestionApplicationSecret',
+                'ApiDomain':  'api.github.com',
                 'Authentication' : {
                     'Type' : 'Basic',
                     'Identity' : 'msftgits',
@@ -58,8 +62,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Tests.Authentication
                             'GitHubAppKeyUri' : 'https://dummyuri.com/'
                         },
                     }
-                },
-                'ApiDomain':  'api.github.com'
+                }
             }";
 
             this.configManager = new GitHubConfigManager(jsonInput);
@@ -84,7 +87,7 @@ namespace Microsoft.CloudMine.Core.Collectors.Tests.Authentication
             string identifier = "identifier";
             FunctionContext functionContext = new FunctionContext();
             FunctionContextWriter<FunctionContext> contextWriter = new FunctionContextWriter<FunctionContext>();
-            AdlsClientWrapper adlsClientWrapper = new AdlsClientWrapper();
+            AdlsClientWrapper adlsClientWrapper = new AdlsClientWrapper(this.jsonInput);
             List<IRecordWriter> recordWriters = storageManager.InitializeRecordWriters(identifier, functionContext, contextWriter, adlsClientWrapper.AdlsClient);
             Assert.AreEqual(2, recordWriters.Count);
             Assert.IsTrue(recordWriters[0] is AdlsBulkRecordWriter<FunctionContext>);


### PR DESCRIPTION
These changes are required due to the changes in [this ](https://github.com/microsoft/CEDAR.Core.Collector/pull/42) CEDAR/Core pull request.

The local and global settings templates all needed to be updated to reflect the movement of the ADLS ingestion app details from local to global settings. This involved moving one key `AdlsIngestionApplicationId` out of local settings. The local and global settings barebones templates needed to be updated because they contained incorrect formatting (an issue I previously pushed to CEDAR/GitHub, my IDE was not configured correctly).

In `ServiceStartup.Configure()`, I added the global settings string to builder services so that I could access it in `AdlsClientWrapper()`.

Finally, I updated `GitHubConfigManagerTests()` to use the newly added ADLS ingestion app details in global settings and the updated `AdlsClientWrapper()` constructor.