### PR TITLE
Fix collection failures when users/ API return 403

### DIFF
--- a/GitHub.Collectors.Functions/host.json
+++ b/GitHub.Collectors.Functions/host.json
@@ -11,7 +11,7 @@
       "enableDependencyTracking": false
     }
   },
-  "functionTimeout": "7.00:00:00",
+  "functionTimeout": "12:00:00",
   "extensions": {
     "queues": {
       "visibilityTimeout": "00:15:00",

--- a/GitHub.Collectors/Model/DefaultCollector.cs
+++ b/GitHub.Collectors/Model/DefaultCollector.cs
@@ -20,6 +20,7 @@ namespace Microsoft.CloudMine.GitHub.Collectors.Model
     public class DefaultCollector : ICollector
     {
         public static readonly HttpResponseSignature UserNotFoundResponse = new HttpResponseSignature(HttpStatusCode.NotFound, "Not Found");
+        public static readonly HttpResponseSignature ResourceNotAccessibleByIntegrationResponse = new HttpResponseSignature(HttpStatusCode.Forbidden, "Resource not accessible by integration");
 
         public const string OrganizationInstanceRecordType = "GitHub.OrgIstance";
         public const string UserInstanceRecordType = "GitHub.UserInstance";
@@ -60,9 +61,11 @@ namespace Microsoft.CloudMine.GitHub.Collectors.Model
             {
                 string senderUrl = senderUrlToken.Value<string>();
                 // There are cases where we receive this payload for removed team members, members no longer exist in GitHub. Therefore, the following call can fail with 404 not found.
+                // When using a GitHub app, the same request fails with 403: "Resource not accessible by integration" response.
                 List<HttpResponseSignature> allowlistedResponses = new List<HttpResponseSignature>()
                 {
                     UserNotFoundResponse,
+                    ResourceNotAccessibleByIntegrationResponse,
                 };
                 await this.ProcessUrlAsync(senderUrl, UserInstanceRecordType, allowlistedResponses).ConfigureAwait(false);
             }


### PR DESCRIPTION
When using a GitHub app, the users/ API return 403 instead of 404 when a user no longer exists. Allowlist this response so that the collectors no longer fail.

Also, reduce back the function duration to 12 hours.