### PR TITLE
Ignore security_advosory events

### DIFF
--- a/GitHub.Collectors.Functions/GitHubFunctions.cs
+++ b/GitHub.Collectors.Functions/GitHubFunctions.cs
@@ -101,8 +101,15 @@ namespace Microsoft.CloudMine.GitHub.Collectors.Functions
                 throw new FatalException(errorMessage);
             }
             string eventType = eventTypeValues.First();
-            // Temporarily ignore processing secret_scanning_alert events since our collectors are failing because of the load.
-            if (eventType.Equals("secret_scanning_alert"))
+
+            // Temporarily ignore processing secret_scanning_alert and security_advisory events since our collectors are failing because of the load.
+            HashSet<string> ignoreEvents = new HashSet<string>()
+            {
+                "secret_scanning_alert",
+                "security_advisory"
+            };
+
+            if (ignoreEvents.Contains(eventType))
             {
                 return new HttpResponseMessage(System.Net.HttpStatusCode.OK);
             }

--- a/GitHub.Collectors.Functions/GitHubFunctions.cs
+++ b/GitHub.Collectors.Functions/GitHubFunctions.cs
@@ -102,7 +102,8 @@ namespace Microsoft.CloudMine.GitHub.Collectors.Functions
             }
             string eventType = eventTypeValues.First();
 
-            // Temporarily ignore processing secret_scanning_alert and security_advisory events since our collectors are failing because of the load.
+            // Temporarily ignore processing secret_scanning_alert events since our collectors are failing because of the load.
+            // Temporarily ignore processing security_advisory events since they never contain required organization name.
             HashSet<string> ignoreEvents = new HashSet<string>()
             {
                 "secret_scanning_alert",

--- a/GitHub.Collectors.Functions/GitHubFunctions.cs
+++ b/GitHub.Collectors.Functions/GitHubFunctions.cs
@@ -102,11 +102,11 @@ namespace Microsoft.CloudMine.GitHub.Collectors.Functions
             }
             string eventType = eventTypeValues.First();
 
-            // Temporarily ignore processing secret_scanning_alert events since our collectors are failing because of the load.
-            // Temporarily ignore processing security_advisory events since they never contain required organization name.
             HashSet<string> ignoreEvents = new HashSet<string>()
             {
+                // Temporarily ignore processing secret_scanning_alert events since our collectors are failing because of the load.
                 "secret_scanning_alert",
+                // Temporarily ignore processing security_advisory events since they never contain required organization name.
                 "security_advisory"
             };
 


### PR DESCRIPTION
## Changes
- ignore `security_advisory` webhook events pushed to webhook processor. These events do not contain an organization name which is currently required. (ICM Link: https://portal.microsofticm.com/imp/v3/incidents/details/322801093/home)